### PR TITLE
Set Parts Visibility to Show Parts on 3D view before activating it

### DIFF
--- a/StoneDocuments/Check/cmdCheck.cs
+++ b/StoneDocuments/Check/cmdCheck.cs
@@ -79,6 +79,16 @@ namespace StoneDocuments
                 return Result.Failed;
             }
 
+            if (curView.PartsVisibility != PartsVisibility.ShowPartsOnly)
+            {
+                using (Transaction t = new Transaction(curDoc))
+                {
+                    t.Start("Set Parts Visibility");
+                    curView.PartsVisibility = PartsVisibility.ShowPartsOnly;
+                    t.Commit();
+                }
+            }
+
             uidoc.ActiveView = curView;
 
             uidoc.Selection.SetElementIds(elemIdList);


### PR DESCRIPTION
Ensures the default 3D view displays parts correctly before switching to it and selecting elements from the schedule.

https://claude.ai/code/session_01UGfGbNPzSctDkFzZh44o7j